### PR TITLE
Move the kernel modules list to an explicitly specified list.

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -351,39 +351,7 @@ ${INSTALL_DEF_FILE} ${X_STAGING_TMPDIR}/board.cfg ${X_STAGING_FSROOT}/c/etc/
 if [ "x${MFSROOT_INC_MODULES}" = "xYES" ]; then
 	echo "*** Including modules.."
 
-	# The AR9130 build (which uses if_ath_ahb) doesn't yet build right
-	# from modules (without hacking sys/modules/ath/Makefile)
-	# so there's no point in keeping it.
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_ath.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_ath_pci.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# networking related stuff
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/bridgestp.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_bridge.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_gif.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_gre.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_vlan.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ipfw.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# misc stuff
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/random.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# wlan modules
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_acl.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_amrr.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_ccmp.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_rssadapt.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_tkip.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_wep.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_xauth.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# Cut down set of usb modules
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/usb.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ehci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ohci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/umass.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ar71xx_ehci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ar71xx_ohci.ko ${X_STAGING_FSROOT}/boot/kernel/
+	for i in ${MFSROOT_INC_MODULE_LIST}; do
+		${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/${i}.ko ${X_STAGING_FSROOT}/boot/kernel/
+	done
 fi
-

--- a/build/bin/build_tinymfsroot
+++ b/build/bin/build_tinymfsroot
@@ -308,40 +308,8 @@ ${INSTALL_DEF_BIN} ${X_STAGING_TMPDIR}/board.cfg ${X_STAGING_FSROOT}/c/etc
 if [ "x${MFSROOT_INC_MODULES}" = "xYES" ]; then
 	echo "*** Including modules.."
 
-	# The AR9130 build (which uses if_ath_ahb) doesn't yet build right
-	# from modules (without hacking sys/modules/ath/Makefile)
-	# so there's no point in keeping it.
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_ath.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_ath_pci.ko ${X_STAGING_FSROOT}/boot/kernel/
+	for i in ${MFSROOT_INC_MODULE_LIST}; do
+		${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/${i}.ko ${X_STAGING_FSROOT}/boot/kernel/
+	done
 
-	# networking related stuff
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/bridgestp.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_bridge.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_gif.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/if_gre.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# misc stuff
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/random.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# wlan modules
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_acl.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_amrr.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_ccmp.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_rssadapt.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_tkip.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_wep.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/wlan_xauth.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# Cut down set of usb modules
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/usb.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ehci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/uhci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ohci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/umass.ko ${X_STAGING_FSROOT}/boot/kernel/
-
-	# .. and the USB bus glue
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ar71xx_ehci.ko ${X_STAGING_FSROOT}/boot/kernel/
-	${INSTALL_DEF_KLD} ${X_DESTDIR}/boot/kernel.${KERNCONF}/ar71xx_ohci.ko ${X_STAGING_FSROOT}/boot/kernel/
 fi
-

--- a/build/cfg/ap135
+++ b/build/cfg/ap135
@@ -13,6 +13,7 @@ BIN_CFG_SIZE="65536"
 
 # Modules need to be included
 MFSROOT_INC_MODULES="YES"
+MFSROOT_INC_MODULE_LIST="if_vlan if_gif if_gre"
 
 # Uboot stuff
 UBOOT_ARCH="mips"

--- a/build/cfg/tl-wr1043ndv2
+++ b/build/cfg/tl-wr1043ndv2
@@ -13,6 +13,7 @@ BIN_CFG_SIZE="65536"
 
 # Modules need to be included
 MFSROOT_INC_MODULES="YES"
+MFSROOT_INC_MODULE_LIST="if_vlan if_gif if_gre"
 
 # Make a ulzma image
 X_FSIMAGE_CMD="mkulzma"


### PR DESCRIPTION
Different board configurations may have different kernel modules
as part of trying to fit things into the space requirements.
So for now, until images get all the same modules, let's just
specify them here as a list.

This has the added benefit of not causing an exit status of non-zero
if the install fails; causing build to stop running any future
install steps.