### PR TITLE
[enhancement] add devinfo into mfsroot

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -161,6 +161,10 @@ ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/vmstat ${X_STAGING_FSROOT}/usr/bin/
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/systat ${X_STAGING_FSROOT}/usr/bin/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libdevstat.so.7 ${X_STAGING_FSROOT}/lib/
 
+# devinfo is useful
+${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/devinfo ${X_STAGING_FSROOT}/usr/sbin/
+${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libdevinfo.so.6 ${X_STAGING_FSROOT}/usr/lib/
+
 # libraries are for grep, tar, cpio, df
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/tar ${X_STAGING_FSROOT}/usr/bin/
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/cpio ${X_STAGING_FSROOT}/usr/bin/


### PR DESCRIPTION
Hi,

It's useful to have devinfo to list drivers & allocated resources. It's small routine (15K = bin+lib), so there is no significant overhead on mfsroot size. 