### PR TITLE
[fix] cfg_load should read only one buffer

### DIFF
--- a/build/files/cfg_load
+++ b/build/files/cfg_load
@@ -6,6 +6,6 @@
 
 echo "*** Restoring from ${CFG_PATH} .. "
 cd /
-dd if=${CFG_PATH} bs=${CFG_SIZE} | gunzip | cpio -iudv || exit 1
+dd if=${CFG_PATH} bs=${CFG_SIZE} count=1 | gunzip | cpio -iudv || exit 1
 
 echo "*** Completed."


### PR DESCRIPTION
This fix just adds count=1 to dd of cfg_load. cfg_save stores only one buffer, but cfg_load doesn't specify amount of buffers to be read. If partition is 128K, but CFG_SIZE is 64K, it fails on load, but fine on save.  