### PR TITLE
[fix] 11-ALPHA libkvm.so increased version

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -289,7 +289,7 @@ ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libsbuf.so.6 ${X_STAGING_FSROOT}/lib/
 # install ${X_DESTDIR}/lib/libipx.so.5 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libutil.so.9 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libkiconv.so.4 ${X_STAGING_FSROOT}/lib/
-${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libkvm.so.6 ${X_STAGING_FSROOT}/lib/
+${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libkvm.so.7 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libnv.so.0 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libpcap.so.8 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libcrypto.so.8 ${X_STAGING_FSROOT}/lib/


### PR DESCRIPTION
Few routines like netstat use libkvm. On 11-ALPHA version has been increased.
Hi @erikarn, what is best way to increase version of libkvm without regression for old snapshots of FreeBSD?
