### PR TITLE
(cosmetic) add ability to include KRB libs for telnet

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -249,13 +249,16 @@ ${INSTALL_SUID_BIN} ${X_DESTDIR}/usr/bin/su ${X_STAGING_FSROOT}/usr/bin/
 
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/telnet ${X_STAGING_FSROOT}/usr/bin/
 # kerberos libraries needed for telnet/telnetd
-# install ${X_DESTDIR}/usr/lib/libkrb5.so.11 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libwind.so.11 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libheimbase.so.11 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libhx509.so.11 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libasn1.so.11 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libcom_err.so.5 ${X_STAGING_FSROOT}/usr/lib
-#install ${X_DESTDIR}/usr/lib/libroken.so.11 ${X_STAGING_FSROOT}/usr/lib
+if [ "x${X_MFS_KERBEROS}" == "xyes" ]; then
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libkrb5.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libwind.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libheimbase.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libprivateheimipcc.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libhx509.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libasn1.so.11 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libcom_err.so.5 ${X_STAGING_FSROOT}/usr/lib
+	${INSTALL_DEF_LIB}  ${X_DESTDIR}/usr/lib/libroken.so.11 ${X_STAGING_FSROOT}/usr/lib
+fi
 
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/inetd ${X_STAGING_FSROOT}/usr/sbin/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libwrap.so.6 ${X_STAGING_FSROOT}/usr/lib/


### PR DESCRIPTION
This patch uncomment kerberos libraries and make them optional. For a while, it allows easy to fix telnet.
