### PR TITLE
Remove shell "x$var" construct

### DIFF
--- a/build/bin/build
+++ b/build/bin/build
@@ -16,7 +16,7 @@ USER_SETTINGS=${USER_SETTINGS:-${HOME}/.freebsd-wifi-build-settings.cfg}
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -31,7 +31,7 @@ USER_ID="`id -u`"
 if [ "${USER_ID}" -eq "0" ]; then
 	echo "*** NOTE: running as root - you don't have to do this!"
 	echo "*** These build scripts will function correctly as non-root!"
-	if [ "x${BUILD_AS_ROOT}" != "xYES" ]; then
+	if [ "${BUILD_AS_ROOT}" != "YES" ]; then
 		echo "*** To run as root, set BUILD_AS_ROOT=YES when building"
 		exit 1
 	fi
@@ -49,13 +49,13 @@ echo "*** Platform		: $BUILDNAME"
 # If it's buildimg, then BUILDIMG target list.
 # If it's cleanimg, then CLEANIMG target list.
 # If it's cleanall, then CLEANALL target list.
-if [ "x$1" = "x" ]; then
+if [ -z "$1" ]; then
 	X_BUILD_LIST="${X_BUILD_BUILD_THINGS_DEFAULTS} ${X_BUILD_BUILD_IMG_DEFAULTS}"
-elif [ "x$1" = "xbuildimg" ]; then
+elif [ "$1" = "buildimg" ]; then
 	X_BUILD_LIST=${X_BUILD_BUILD_IMG_DEFAULTS}
-elif [ "x$1" = "xcleanimg" ]; then
+elif [ "$1" = "cleanimg" ]; then
 	X_BUILD_LIST=${X_BUILD_CLEANIMG_DEFAULTS}
-elif [ "x$1" = "xcleanall" ]; then
+elif [ "$1" = "cleanall" ]; then
 	X_BUILD_LIST=${X_BUILD_CLEANALL_DEFAULTS}
 else
 	X_BUILD_LIST=$*

--- a/build/bin/build_airstation
+++ b/build/bin/build_airstation
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_cleanobj
+++ b/build/bin/build_cleanobj
@@ -10,7 +10,7 @@ shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_cleanroot
+++ b/build/bin/build_cleanroot
@@ -10,7 +10,7 @@ shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_dlink
+++ b/build/bin/build_dlink
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_freebsd
+++ b/build/bin/build_freebsd
@@ -31,7 +31,7 @@ shift
 
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -40,7 +40,7 @@ fi
 
 test -e ${USER_SETTINGS} && . ${USER_SETTINGS}
 
-if [ "x${X_SETX_DEBUG}" = "xYES" ]; then
+if [ "${X_SETX_DEBUG}" = "YES" ]; then
   set -x
 fi
 
@@ -52,7 +52,7 @@ mkdir -p ${X_DESTDIR} || exit 1
 # XXX double-check this works, especially with the escaping and parameter list
 # stuff.
 X_LOCAL_TOOL_DIRS=""
-if [ "x${LOCAL_TOOL_DIRS}" != "x" ]; then
+if [ -n "${LOCAL_TOOL_DIRS}" ]; then
 	X_LOCAL_TOOL_DIRS="LOCAL_TOOL_DIRS=\"${LOCAL_TOOL_DIRS}\""
 fi
 
@@ -64,7 +64,7 @@ echo "" > ${X_DESTDIR}/../../src.conf.${BUILDNAME}
 echo 'KERN_DEBUGDIR=""' > ${X_DESTDIR}/../src.conf.${BUILDNAME}
 
 # Stuff for AP builds
-if [ "x${X_SKIP_AP_STUFF}" = "xYES" ]; then
+if [ "${X_SKIP_AP_STUFF}" = "YES" ]; then
 	echo 'WITHOUT_KERBEROS="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
 	echo 'WITHOUT_KERBEROS_SUPPORT="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
 	echo 'WITHOUT_NIS="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
@@ -81,10 +81,10 @@ fi
 # For now, AP builds get MALLOC_PRODUCTION, but full-root builds
 # don't.
 
-if [ "x${X_SKIP_AP_STUFF}" = "xYES" ]; then
+if [ "${X_SKIP_AP_STUFF}" = "YES" ]; then
 	echo "MALLOC_PRODUCTION=" >> ${X_DESTDIR}/../make.conf.${BUILDNAME}
 fi
-if [ "x$X_SKIP_MORE_STUFF" = "xYES" ]; then
+if [ "$X_SKIP_MORE_STUFF" = "YES" ]; then
 	echo 'WITHOUT_GAMES="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
 	echo 'WITHOUT_DOCS="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
 	echo 'WITHOUT_MAN="YES"' >> ${X_DESTDIR}/../src.conf.${BUILDNAME}
@@ -110,7 +110,7 @@ if [ "x${X_DTS_FILE}" != "x" ]; then
 	X_FDT_DTS_FILE="FDT_DTS_FILE=${X_DTS_FILE}"
 fi
 
-while [ "x$1" != "x" ]; do
+while [ -n "$1" ]; do
 	echo "*** Stage		: $1"
 	if [ "$1" = "installworld" ]; then
 		mkdir -p ${X_DESTDIR}/usr/local/bin/
@@ -133,7 +133,7 @@ while [ "x$1" != "x" ]; do
 	# Always set it for world builds; don't set it for kernel builds
 	X_TARGET_CPUTYPE="TARGET_CPUTYPE=${TARGET_CPUTYPE}"
 	if [ "$1" = "buildkernel" -o "$1" = "installkernel" ]; then
-		if [ "x${KERN_NO_TARGET_CPUTYPE}" = "xyes" ]; then
+		if [ "${KERN_NO_TARGET_CPUTYPE}" = "yes" ]; then
 			X_TARGET_CPUTYPE=""
 		fi
 	fi

--- a/build/bin/build_fsimage
+++ b/build/bin/build_fsimage
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_fullfsimage
+++ b/build/bin/build_fullfsimage
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_fullroot
+++ b/build/bin/build_fullroot
@@ -12,7 +12,7 @@ shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -11,7 +11,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -372,7 +372,7 @@ cat ${X_BASEDIR}/files/ttys | sed "s|@DEF_TTY@|${X_CFG_DEFAULT_TTY}|" \
 ${INSTALL_DEF_FILE} ${X_STAGING_TMPDIR}/ttys ${X_STAGING_FSROOT}/c/etc/
 
 # kernel modules - if required
-if [ "x${MFSROOT_INC_MODULES}" = "xYES" ]; then
+if [ "${MFSROOT_INC_MODULES}" = "YES" ]; then
 	echo "*** Including modules.."
 
 	for i in ${MFSROOT_INC_MODULE_LIST}; do

--- a/build/bin/build_netboot
+++ b/build/bin/build_netboot
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_ralink
+++ b/build/bin/build_ralink
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_tinymfsroot
+++ b/build/bin/build_tinymfsroot
@@ -10,7 +10,7 @@ shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -326,7 +326,7 @@ cat ${X_BASEDIR}/files/rc.conf | sed "s|@DEF_ETH@|${X_CFG_DEFAULT_ETHER}|" \
 ${INSTALL_DEF_FILE} ${X_STAGING_TMPDIR}/rc.conf ${X_STAGING_FSROOT}/c/etc/cfg/
 
 # kernel modules - if required
-if [ "x${MFSROOT_INC_MODULES}" = "xYES" ]; then
+if [ "${MFSROOT_INC_MODULES}" = "YES" ]; then
 	echo "*** Including modules.."
 
 	for i in ${MFSROOT_INC_MODULE_LIST}; do

--- a/build/bin/build_tplink
+++ b/build/bin/build_tplink
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -19,10 +19,10 @@ fi
 # This builds a tplink system image from the given kernel and MFS.
 
 # gzip or lzma the kernel image
-if [ x${TPLINK_COMPRESSION_GZIP} = "xYES" ]; then
+if [ "${TPLINK_COMPRESSION_GZIP}" = "YES" ]; then
 	cat ${X_KERNEL} | gzip -9 | dd of=${X_KERNEL}.gz
 	TPLINK_KERNEL=${X_KERNEL}.gz
-elif [ x${TPLINK_COMPRESSION_LZMA} = "xYES" ]; then
+elif [ "${TPLINK_COMPRESSION_LZMA}" = "YES" ]; then
 	/usr/local/bin/lzma e ${X_KERNEL} ${X_KERNEL}.lzma || exit 1
 	TPLINK_KERNEL=${X_KERNEL}.lzma
 fi
@@ -40,12 +40,12 @@ make -C ${SCRIPT_DIR}/../../programs/mktplinkfw2  || exit 1
 X_ROOTFS_CMDOPT=""
 X_ROOTFS_SKIPOPT="-c"
 
-if [ "x${TPLINK_SKIP_ROOTFS}" = "xNO" ]; then
+if [ "${TPLINK_SKIP_ROOTFS}" = "NO" ]; then
 	X_ROOTFS_CMDOPT="-r ${X_FSIMAGE}${X_FSIMAGE_SUFFIX}"
 	X_ROOTFS_SKIPOPT="-a 0x10000"
 fi
 
-if [ "x${TPLINK_CONFIG_STYLE}" = "xNEW" ]; then
+if [ "${TPLINK_CONFIG_STYLE}" = "NEW" ]; then
 	${SCRIPT_DIR}/../../programs/mktplinkfw/mktplinkfw \
 		-H ${TPLINK_HARDWARE_ID} \
 		-W ${TPLINK_HARDWARE_VER} \
@@ -60,7 +60,7 @@ if [ "x${TPLINK_CONFIG_STYLE}" = "xNEW" ]; then
 		${X_ROOTFS_CMDOPT} \
 		${X_ROOTFS_SKIPOPT} \
 		-o ${X_TFTPBOOT}/${CFGNAME}.factory.bin
-elif [ "x${X_MFSROOT}" = "xYES" ]; then
+elif [ "${X_MFSROOT}" = "YES" ]; then
 # Create firmware suitable for TFTP
 	${SCRIPT_DIR}/../../programs/mktplinkfw/mktplinkfw	\
 	     -B ${TPLINK_BOARDTYPE} -R ${TPLINK_ROOTFS_START} \

--- a/build/bin/build_ubnt
+++ b/build/bin/build_ubnt
@@ -9,7 +9,7 @@ CFGNAME=$1
 shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 

--- a/build/bin/build_uboot
+++ b/build/bin/build_uboot
@@ -10,7 +10,7 @@ shift
 . ${SCRIPT_DIR}/../cfg/${CFGNAME} || exit 1
 
 # If X_BUILD_BASE_CFG is set, also load that in.
-if [ "x${X_BUILD_BASE_CFG}" != "x" ]; then
+if [ -n "${X_BUILD_BASE_CFG}" ]; then
 	. ${SCRIPT_DIR}/../cfg/base/${X_BUILD_BASE_CFG} || exit 1
 fi
 
@@ -36,7 +36,7 @@ mkimage -A ${UBOOT_ARCH} -O linux -T kernel -C lzma \
 
 # If this is a carambola we can also create a single image with both the kernel and
 # filesystem, to make flashing more efficient.
-if [ "x${X_UBOOT_KERNROOTIMG}" = "xYES" ] ; then
+if [ "${X_UBOOT_KERNROOTIMG}" = "YES" ] ; then
   X_FLASH=${X_TFTPBOOT}/${CFGNAME}.flashinst.img
   (
     dd if=${X_TFTPBOOT}/kernel.${KERNCONF}.lzma.uImage bs=65536 conv=sync || exit 1


### PR DESCRIPTION
The [ "x$var" = "x" ] form hasn't been necessary for years, for any
reasonable shell.