### PR TITLE
[mfsroot] add USB routines as option (+80Kb)

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -258,7 +258,7 @@ ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/telnet ${X_STAGING_FSROOT}/usr/bin/
 #install ${X_DESTDIR}/usr/lib/libroken.so.11 ${X_STAGING_FSROOT}/usr/lib
 
 #usb
-if [ "x${X_MFS_USB}" == "xyes" ]; then
+if [ "${X_MFS_USB}" == "yes" ]; then
 	${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/usbconfig ${X_STAGING_FSROOT}/usr/sbin/
 	${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libusb.so.3 ${X_STAGING_FSROOT}/usr/lib/
 fi

--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -257,6 +257,12 @@ ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/bin/telnet ${X_STAGING_FSROOT}/usr/bin/
 #install ${X_DESTDIR}/usr/lib/libcom_err.so.5 ${X_STAGING_FSROOT}/usr/lib
 #install ${X_DESTDIR}/usr/lib/libroken.so.11 ${X_STAGING_FSROOT}/usr/lib
 
+#usb
+if [ "x${X_MFS_USB}" == "xyes" ]; then
+	${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/usbconfig ${X_STAGING_FSROOT}/usr/sbin/
+	${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libusb.so.3 ${X_STAGING_FSROOT}/usr/lib/
+fi
+
 ${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/inetd ${X_STAGING_FSROOT}/usr/sbin/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libwrap.so.6 ${X_STAGING_FSROOT}/usr/lib/
 ${INSTALL_DEF_FILE} ${X_BASEDIR}/files/inetd.conf ${X_STAGING_FSROOT}/c/etc/

--- a/build/cfg/bcm-trx
+++ b/build/cfg/bcm-trx
@@ -15,3 +15,7 @@ X_MAKEFS_FLAGS_EXT="label=FBSD"
 
 # Building the firmware image
 X_BUILD_BUILD_IMG_DEFAULTS="mfsroot fsimage trx"
+
+# MFS options
+X_MFS_USB=yes
+


### PR DESCRIPTION
Hi,

This patch addes option to include USB into mfs. If option is enabled, total size is increased on 80Kb.

Tested:
 - build with enabled/disabled option. 
 - usbconfig on MIPS board Asus RT-N53. 