### PR TITLE
portbld =unknown in latest versions of mips-xtoolchain-gcc

### DIFF
--- a/port-build/scripts/cross_build.mips
+++ b/port-build/scripts/cross_build.mips
@@ -6,7 +6,7 @@ X_ROOTDIR="${X_PACKAGE_ROOTDIR}"
 X_PKG_CPU_ARGS="-march=mips32 -msoft-float -Wa,-msoft-float"
 X_PKG_INCS="-I${X_ROOTDIR}/usr/include"
 
-X_PKG_CROSS_COMPILE=mips-portbld-freebsd12.0
+X_PKG_CROSS_COMPILE=mips-unknown-freebsd12.0
 
 X_PKG_SYSROOT="${X_ROOTDIR}"
 X_PKG_CFLAGS=""
@@ -22,10 +22,10 @@ X_PKG_RANLIB=mips-freebsd-ranlib
 X_PKG_STRIP=mips-freebsd-strip
 
 
-X_PKG_CONFIGURE_HOSTFLAGS="--host=mips-portbld-freebsd12.0"
+X_PKG_CONFIGURE_HOSTFLAGS="--host=mips-unknown-freebsd12.0"
 
 # now run:
-# /configure --host=mips-portbld-freebsd12.0
+# /configure --host=mips-unknown-freebsd12.0
 # gmake
 
 #$*


### PR DESCRIPTION
As of ports r428312, s/portbld/unknown in devel/mips-gcc

The subsequent r428604 fixes devel/mips-xtoolchain-gcc to build again