### PR TITLE
Make sure that netboot kernel is writable before copying mfsroot into it and fail if not

### DIFF
--- a/build/bin/build_netboot
+++ b/build/bin/build_netboot
@@ -18,7 +18,7 @@ fi
 
 # get the kernel MFS size
 # this sets mfs_ofs, mfs_end, mfs_start, mfs_size
-cp ${X_KERNEL} ${X_KERNEL}.netboot
+install -m 755 ${X_KERNEL} ${X_KERNEL}.netboot
 
 mfs_size=`stat -f '%z' ${X_FSIMAGE}${X_FSIMAGE_SUFFIX} 2> /dev/null`
 # If we can't determine MFS image size - bail.
@@ -40,8 +40,8 @@ echo "*** copying the mfsroot into the kernel image"
 # Dump the mfs image into the mfs section
 dd if=${X_FSIMAGE}${X_FSIMAGE_SUFFIX} ibs=8192 \
     of=${X_KERNEL}.netboot obs=${sec_start} oseek=1 \
-    conv=notrunc 2> /dev/null && \
-    echo "MFS image embedded into kernel" && exit 0
+    conv=notrunc 2> /dev/null
+[ $? -ne 0 ] && echo "Can't embed MFS image into kernel" && exit 1
 
 echo "*** generate md5 for ${X_KERNEL}.netboot"
 md5 -q ${X_KERNEL}.netboot > ${X_KERNEL}.netboot.md5


### PR DESCRIPTION
Hi,
I've noticed that when I try to build a netboot image, the `dd` command in `build_netboot` silently fails when copying the mfsroot into the kernel file. The issue seems to be caused by the .netboot copy of the kernel file not having write permission.
I'm experiencing this while building a firmware image for an MT7628 based board using the `ralink` cfg.
This patch works for me, producing a firmware image with the mfsroot embedded into the kernel.
Maybe am I missing something else?
Thanks