### PR TITLE
[cross-build] add "fetch" step into default list of pkgbuild

### DIFF
--- a/port-build/scripts/cross_build
+++ b/port-build/scripts/cross_build
@@ -91,7 +91,7 @@ runcmd()
 }
 
 if [ "x$1" = "x" ]; then
-	CMDLIST="clean unpack patch configure build staging files package"
+	CMDLIST="clean fetch unpack patch configure build staging files package"
 else
 	CMDLIST="$*"
 fi


### PR DESCRIPTION
Hi Adrian,

If you try to build pkgs at first time, it fails due to missing distfiles and actual error is in middle of output. It takes time to find root cause. :( That's why it's worth to increase "fetch" step into default chain of commands.