### PR TITLE
[monitoring] add prometheus support, expose few metrics

### DIFF
--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -406,6 +406,9 @@ ${INSTALL_DEF_FILE} ${X_DESTDIR}/etc/protocols ${X_STAGING_FSROOT}/c/etc/
 # this is needed for inetd
 ${INSTALL_DEF_FILE} ${X_DESTDIR}/etc/netconfig ${X_STAGING_FSROOT}/c/etc/
 
+# monitoring
+${INSTALL_DEF_BIN} ${X_DESTDIR}/usr/sbin/prometheus_sysctl_exporter ${X_STAGING_FSROOT}/usr/sbin/
+
 # Local board setup
 echo "# Configuration for: ${KERNCONF}" > ${X_STAGING_TMPDIR}/board.cfg
 echo "CFG_PATH=\"${BIN_CFG_PARTITION}\"" >> ${X_STAGING_TMPDIR}/board.cfg

--- a/build/files/inetd.conf
+++ b/build/files/inetd.conf
@@ -1,2 +1,2 @@
-telnet	stream	tcp	nowait	root	/usr/libexec/telnetd	telnetd
-
+telnet		stream	tcp	nowait	root	/usr/libexec/telnetd			telnetd
+prom-sysctl	stream	tcp	nowait	nobody	/usr/sbin/prometheus_sysctl_exporter	prometheus_sysctl_exporter	-dgh	vm.loadavg hw.physmem hw.ncpu dev.gpioths


### PR DESCRIPTION
Hi,

This patch add fresh prometheus_sysctl_exporter to monitor device via inetd. 
Metrics to expose: loadavg & physmem & ncpu & temperature (via gpioths). Even if sysctl is unavailable, it doesn't fail, it exports existing sysctl-es.
