### PR TITLE
Fix tl-wr1043ndv2: add missed target "makepkgs"

### DIFF
--- a/build/cfg/tl-wr1043ndv2
+++ b/build/cfg/tl-wr1043ndv2
@@ -39,4 +39,4 @@ X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 TARGET_CROSS_TOOLCHAIN="mips-gcc"
 
 # Building the firmware image
-X_BUILD_BUILD_IMG_DEFAULTS="mfsroot addpkgs fsimage tplink"
+X_BUILD_BUILD_IMG_DEFAULTS="mfsroot makepkgs addpkgs fsimage tplink"


### PR DESCRIPTION
This change fixes bug #117. Before adding binary packages we need to build them via makepkgs.