### PR TITLE
[mktrxfw] avoid hard-coded triple of mips-gcc

### DIFF
--- a/programs/mktrxfw/Makefile
+++ b/programs/mktrxfw/Makefile
@@ -1,7 +1,7 @@
 RM?=	rm
 LDFLAGS+=	-lz -lcrypto
 PREFIX?=	/usr/local
-MIPSCC=mips-portbld-freebsd10.2-gcc
+MIPSCC!=(pkg info -l mips-gcc | grep '\-gcc$$')
 MIPSOBJECTS=trxloader.o tinfl.o mem.o
 MIPSCFLAGS=-EL -O1 -g -fno-pic -mno-abicalls -nostdlib -I/usr/include
 GZIP=gzip -nc9


### PR DESCRIPTION
This change fixes build of mktrxfw on non-10.2 platforms. 
This is short-term bit, because of future plan to use Clang. For a while, let's extract path to mips-gcc from pkg. It's not nice, but it's less surprise thing.