### PR TITLE
[build_airstation] fix entry address

### DIFF
--- a/build/bin/build_airstation
+++ b/build/bin/build_airstation
@@ -24,6 +24,12 @@ fi
 
 /usr/local/bin/lzma e ${X_KERNEL} ${X_TFTPBOOT}/kernel.${KERNCONF}.lzma || exit 1
 
+X_KERN_ELF_STARTADDR="`/usr/bin/elfdump -e ${X_KERNEL} | grep e_entry | cut -f2 -d: | sed 's@ *@@'`"
+echo "*** UBOOT_KERN_STARTADDR=${UBOOT_KERN_STARTADDR}"
+echo "*** X_KERN_ELF_STARTADDR=${X_KERN_ELF_STARTADDR}"
+
+UBOOT_KERN_STARTADDR=${X_KERN_ELF_STARTADDR}
+
 # Create the firmware
 mkimage -A ${UBOOT_ARCH} -O linux -T kernel -C lzma \
   -a ${UBOOT_KERN_LOADADDR} -e ${UBOOT_KERN_STARTADDR} \


### PR DESCRIPTION
This allows to find entry address by elfdump in same way as done for build_dlink.