### PR TITLE
FreeBSD12+ support

### DIFF
--- a/build/bin/build_freebsd
+++ b/build/bin/build_freebsd
@@ -58,7 +58,7 @@ fi
 
 # Create blank make.conf/src.conf
 echo "" > ${X_DESTDIR}/../make.conf.${BUILDNAME}
-echo "" > ${X_DESTDIR}/../../src.conf.${BUILDNAME}
+echo "" > ${X_DESTDIR}/../src.conf.${BUILDNAME}
 
 # Make a src.conf
 echo 'KERN_DEBUGDIR=""' > ${X_DESTDIR}/../src.conf.${BUILDNAME}

--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -25,7 +25,7 @@ X_BASEDIR=${SCRIPT_DIR}/../
 # Configure INSTALL; to use the FreeBSD install program from -10
 # and -head that knows about mtree updates and non-root installs.
 
-INSTALL_PROG="install -U -M ${X_STAGING_METALOG_MFSROOT} -D ${X_STAGING_FSROOT}"
+INSTALL_PROG="install -v -U -M ${X_STAGING_METALOG_MFSROOT} -D ${X_STAGING_FSROOT}"
 
 INSTALL_DEF_BIN="${INSTALL_PROG} -o root -g wheel -m 0755"
 INSTALL_SUID_BIN="${INSTALL_PROG} -o root -g wheel -m 4711"

--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -334,13 +334,12 @@ ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libcrypt.so.5 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libgcc_s.so.1 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libbsdxml.so.4 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libsbuf.so.6 ${X_STAGING_FSROOT}/lib/
-# install ${X_DESTDIR}/lib/libipx.so.5 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libutil.so.9 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libkiconv.so.4 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libkvm.so.7 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libnv.so.0 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libpcap.so.8 ${X_STAGING_FSROOT}/lib/
-${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libcrypto.so.8 ${X_STAGING_FSROOT}/lib/
+${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libcrypto.so.111 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libm.so.5 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libipsec.so.4 ${X_STAGING_FSROOT}/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/libthr.so.3 ${X_STAGING_FSROOT}/lib/
@@ -349,7 +348,7 @@ ${INSTALL_DEF_LIB} ${X_DESTDIR}/lib/lib80211.so.1 ${X_STAGING_FSROOT}/lib/
 
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libmemstat.so.3 ${X_STAGING_FSROOT}/usr/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libnetgraph.so.4 ${X_STAGING_FSROOT}/usr/lib/
-${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libssl.so.8 ${X_STAGING_FSROOT}/usr/lib/
+${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libssl.so.111 ${X_STAGING_FSROOT}/usr/lib/
 ${INSTALL_DEF_LIB} ${X_DESTDIR}/usr/lib/libmp.so.7 ${X_STAGING_FSROOT}/usr/lib/
 
 # libgpio is a stand alone library now, needed for gpioctl

--- a/build/bin/check_deps
+++ b/build/bin/check_deps
@@ -2,7 +2,7 @@
 
 # This script checks that relevant packages have been installed.
 
-PKG_LIST="uboot-mkimage-2010.12 lzma perl5 rsync mips-xtoolchain-gcc"
+PKG_LIST="uboot-mkimage-2010.12 lzma perl5 rsync mips-gcc6"
 
 retval=0
 for i in ${PKG_LIST}; do

--- a/build/cfg/ap135
+++ b/build/cfg/ap135
@@ -67,4 +67,4 @@ X_CFG_DEFAULT_HOSTNAME="freebsd-ap135"
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/ap93
+++ b/build/cfg/ap93
@@ -67,4 +67,4 @@ X_CFG_DEFAULT_HOSTNAME="freebsd-ap93"
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/base/mips_ap
+++ b/build/cfg/base/mips_ap
@@ -15,4 +15,4 @@ X_SKIP_AP_STUFF="YES"
 X_PORTBUILD_PLATFORM="mips"
 
 # Example using cross toolchain for base system
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/carambola2
+++ b/build/cfg/carambola2
@@ -74,4 +74,4 @@ X_CFG_DEFAULT_HOSTNAME="freebsd-carambola2"
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/db120
+++ b/build/cfg/db120
@@ -75,4 +75,4 @@ X_CFG_DEFAULT_HOSTNAME="freebsd-db120"
 # X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 X_PACKAGELIST="dropbear dnsmasq lua"
 
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/dir825c1
+++ b/build/cfg/dir825c1
@@ -67,5 +67,5 @@ X_BUILD_BUILD_IMG_DEFAULTS="fetchpkgs mfsroot makepkgs addpkgs fsimage uboot"
 
 # packages
 X_PACKAGELIST="dropbear dnsmasq"
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"
 

--- a/build/cfg/enh200
+++ b/build/cfg/enh200
@@ -63,4 +63,4 @@ X_CFG_DEFAULT_HOSTNAME="freebsd-enh200"
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
 
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"

--- a/build/cfg/lssr71
+++ b/build/cfg/lssr71
@@ -33,7 +33,7 @@ X_CFG_DEFAULT_ETHER="arge0"
 X_CFG_DEFAULT_HOSTNAME="freebsd-lssr71"
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"
 
 # Building the firmware image
 #X_BUILD_BUILD_IMG_DEFAULTS="fetchpkgs tinymfsroot makepkgs addpkgs fsimage ubnt"

--- a/build/cfg/tl-wr1043ndv2
+++ b/build/cfg/tl-wr1043ndv2
@@ -36,7 +36,7 @@ TPLINK_HARDWARE_FLASHID=8M
 TPLINK_FIRMWARE_RESERV=0x40000
 
 X_PACKAGELIST="dropbear dnsmasq lua lzo2 openvpn"
-TARGET_CROSS_TOOLCHAIN="mips-gcc"
+TARGET_CROSS_TOOLCHAIN="mips-gcc6"
 
 # Building the firmware image
 X_BUILD_BUILD_IMG_DEFAULTS="mfsroot makepkgs addpkgs fsimage tplink"

--- a/doc/FIRST-STEPS.md
+++ b/doc/FIRST-STEPS.md
@@ -7,7 +7,7 @@ and the router with a LAN cable. The router has a fixed address of
 subnet.
 Use _telnet(1)_ to login as user _user_:
 
-    $ telnet 192.168.1.20
+    $ telnet -K 192.168.1.20
     Trying 192.168.1.20...
     Connected to 192.168.1.20.
     Escape character is '^]'.

--- a/port-build/scripts/cross_build.mips
+++ b/port-build/scripts/cross_build.mips
@@ -6,7 +6,7 @@ X_ROOTDIR="${X_PACKAGE_ROOTDIR}"
 X_PKG_CPU_ARGS="-march=mips32 -msoft-float -Wa,-msoft-float"
 X_PKG_INCS="-I${X_ROOTDIR}/usr/include"
 
-X_PKG_CROSS_COMPILE=$(pkg info -l mips-gcc | grep '\-gcc$' | sed  's/.*\(mips-[^-]\{1,\}-freebsd[^-]\{1,\}\).*/\1/')
+X_PKG_CROSS_COMPILE=$(pkg info -l mips-gcc6 | grep '\-gcc6$' | sed  's/.*\(mips-[^-]\{1,\}-freebsd[^-]\{1,\}\).*/\1/')
 
 X_PKG_SYSROOT="${X_ROOTDIR}"
 X_PKG_CFLAGS=""
@@ -14,8 +14,8 @@ X_PKG_CXXFLAGS=""
 X_PKG_CPPFLAGS=""
 X_PKG_LDFLAGS="--sysroot=${X_PKG_SYSROOT}"
 X_PKG_CC_ARGS="--sysroot=${X_PKG_SYSROOT} ${X_PKG_CPU_ARGS} ${X_PKG_INCS} -O"
-X_PKG_CC="${X_PKG_CROSS_COMPILE}-gcc ${X_PKG_CC_ARGS}"
-X_PKG_CXX="${X_PKG_CROSS_COMPILE}-g++ ${X_PKG_CC_ARGS}"
+X_PKG_CC="${X_PKG_CROSS_COMPILE}-gcc6 ${X_PKG_CC_ARGS}"
+X_PKG_CXX="${X_PKG_CROSS_COMPILE}-g++6 ${X_PKG_CC_ARGS}"
 X_PKG_LD="${X_PKG_CROSS_COMPILE}"-ld
 X_PKG_AR="${X_PKG_CROSS_COMPILE}"-ar
 X_PKG_RANLIB="${X_PKG_CROSS_COMPILE}"-ranlib

--- a/port-build/scripts/cross_build.mipsel
+++ b/port-build/scripts/cross_build.mipsel
@@ -6,7 +6,7 @@ X_ROOTDIR="${X_PACKAGE_ROOTDIR}"
 X_PKG_CPU_ARGS="-march=mips32 -EL -msoft-float -Wa,-msoft-float"
 X_PKG_INCS="-I${X_ROOTDIR}/usr/include"
 
-X_PKG_CROSS_COMPILE=$(pkg info -l mips-gcc | grep '\-gcc$' | sed  's/.*\(mips-[^-]\{1,\}-freebsd[^-]\{1,\}\).*/\1/')
+X_PKG_CROSS_COMPILE=$(pkg info -l mips-gcc6 | grep '\-gcc6$' | sed  's/.*\(mips-[^-]\{1,\}-freebsd[^-]\{1,\}\).*/\1/')
 
 X_PKG_SYSROOT="${X_ROOTDIR}"
 X_PKG_CFLAGS=""
@@ -14,8 +14,8 @@ X_PKG_CXXFLAGS=""
 X_PKG_CPPFLAGS=""
 X_PKG_LDFLAGS="--sysroot=${X_PKG_SYSROOT}"
 X_PKG_CC_ARGS="--sysroot=${X_PKG_SYSROOT} ${X_PKG_CPU_ARGS} ${X_PKG_INCS} -O"
-X_PKG_CC="${X_PKG_CROSS_COMPILE}-gcc ${X_PKG_CC_ARGS}"
-X_PKG_CXX="${X_PKG_CROSS_COMPILE}-g++ ${X_PKG_CC_ARGS}"
+X_PKG_CC="${X_PKG_CROSS_COMPILE}-gcc6 ${X_PKG_CC_ARGS}"
+X_PKG_CXX="${X_PKG_CROSS_COMPILE}-g++6 ${X_PKG_CC_ARGS}"
 X_PKG_LD="${X_PKG_CROSS_COMPILE}"-ld
 X_PKG_AR="${X_PKG_CROSS_COMPILE}"-ar
 X_PKG_RANLIB="${X_PKG_CROSS_COMPILE}"-ranlib

--- a/programs/mktrxfw/Makefile
+++ b/programs/mktrxfw/Makefile
@@ -1,7 +1,7 @@
 RM?=	rm
 LDFLAGS+=	-lz -lcrypto
 PREFIX?=	/usr/local
-MIPSCC!=(pkg info -l mips-gcc | grep '\-gcc$$')
+MIPSCC!=(pkg info -l mips-gcc6 | grep '\-gcc6$$')
 MIPSOBJECTS=trxloader.o tinfl.o mem.o
 MIPSCFLAGS=-EL -O1 -g -fno-pic -mno-abicalls -nostdlib -I/usr/include
 GZIP=gzip -nc9


### PR DESCRIPTION
- Change openssl libs versions to match openssl 1.1 from base.
- Correct path when creating blank src.conf.${BUILDNAME}.
- Make install(1) verbose. That helps you to see in the buildlog later to find what was not installed actually.
- Add -K parameter to telnet(1) in FIRST-STEPS.md doc
- Use mips-gcc6 for now

Tested on my tl-wdr3600.

Note, openssl 1.1's libcrypto.so bumped in size so it's now harder to fit everything into 8 MB.
Also openvpn port has to be updated to support openssl 1.1.
I'll prepare a separate pull request for that.